### PR TITLE
Fix imports to make classes importable

### DIFF
--- a/ramces/__init__.py
+++ b/ramces/__init__.py
@@ -1,0 +1,2 @@
+from .ramces import Ramces
+from .ramces_cnn import SimpleCNN

--- a/ramces/ramces.py
+++ b/ramces/ramces.py
@@ -9,7 +9,7 @@ import torch
 import torchvision.transforms.functional as TF
 from tqdm import tqdm
 
-from ramces_cnn import SimpleCNN
+from .ramces_cnn import SimpleCNN
 
 
 class Ramces:


### PR DESCRIPTION
Fix imports to make classes importable by adding modules to `__init__.py` and use relative import.